### PR TITLE
List Previous Runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
    - Add `-l` flag to link to older log files. (#35)
+   - Add `list` command, to list previous runs. (#37)
 
 ## v1.0.1
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,12 +43,12 @@ jobs:
     STAGING_DIRECTORY_UNIX: /Users/vsts/STAGING
 
   steps:
-  - template: .ci/restore-build-cache.yml
+  # - template: .ci/restore-build-cache.yml
   - template: .ci/esy-build-steps.yml
   - script: cp _build/default/executable/RLog.exe _build/rLog
   - script: strip _build/rLog
   - script: chmod +x _build/rLog
-  - template: .ci/publish-build-cache.yml
+  # - template: .ci/publish-build-cache.yml
   - task: PublishBuildArtifacts@1
     displayName: 'Save artifact'
     inputs:

--- a/executable/RLog.re
+++ b/executable/RLog.re
@@ -46,6 +46,8 @@ let getArgsAndRun = () => {
     Config.makeDefaultConfig(args.configPath^);
   } else if (Cli.isLink(args)) {
     Runner.link(args, logMsg);
+  } else if (Cli.isList(args)) {
+    Runner.printPreviousRuns(args, logMsg);
   };
 
   exit(exitCode^);

--- a/library/Cli.re
+++ b/library/Cli.re
@@ -39,6 +39,11 @@ let argList = cliObj => {
       Arg.Unit(() => ()),
       " Link the passed data file(s) to the previous run.",
     ),
+    (
+      "list",
+      Arg.Unit(() => ()),
+      " List all the completed runs.",
+    ),
     ("-h", Arg.Set(cliObj.showHelp), " Show this help text."),
     ("-v", Arg.Set(cliObj.verbose), " Enable verbose mode."),
     ("-R", Arg.Set(cliObj.recurse), " Recursively link files from folders."),
@@ -92,6 +97,7 @@ let isRun = cliObj => cliObj.command == Types.CommandType.Run;
 let isConfigGen = cliObj => cliObj.command == Types.CommandType.GenerateConfig;
 let isSearch = cliObj => cliObj.command == Types.CommandType.Search;
 let isLink = cliObj => cliObj.command == Types.CommandType.Link;
+let isList = cliObj => cliObj.command == Types.CommandType.ListRuns;
 
 let getArgs = () => {
   let cliObj = default;

--- a/library/Cli.re
+++ b/library/Cli.re
@@ -39,11 +39,7 @@ let argList = cliObj => {
       Arg.Unit(() => ()),
       " Link the passed data file(s) to the previous run.",
     ),
-    (
-      "list",
-      Arg.Unit(() => ()),
-      " List all the completed runs.",
-    ),
+    ("list", Arg.Unit(() => ()), " List all the completed runs."),
     ("-h", Arg.Set(cliObj.showHelp), " Show this help text."),
     ("-v", Arg.Set(cliObj.verbose), " Enable verbose mode."),
     ("-R", Arg.Set(cliObj.recurse), " Recursively link files from folders."),

--- a/library/Logging.re
+++ b/library/Logging.re
@@ -212,18 +212,33 @@ let getLastLogFilePath = (logOutputPath, logMsg) => {
 };
 
 /* Print out every previously ran command, to be grepped over. */
-let printPreviousRuns = (outputPath) => {
+let printPreviousRuns = outputPath => {
   let absPath = makeAbsolutePath(outputPath);
   checkFolderExists(absPath);
 
-  let allMetadataFiles = List.filter(
-    f => Str.string_match(Str.regexp({|.*meta\.log|}), f, 0), getAllFiles([absPath])
-  );
+  let allMetadataFiles =
+    List.filter(
+      f => Str.string_match(Str.regexp({|.*meta\.log|}), f, 0),
+      getAllFiles([absPath]),
+    );
 
-  let _ = List.map(f => Console.log(f), allMetadataFiles);
+  /* Get relative paths for pretty printing. */
+  let relativeMetadataFiles =
+    List.map(m => makeRelativePath(absPath, m), allMetadataFiles);
+
+  let formatCommand = cmd => stripFirstAndLastFromString(cmd, 3, 1);
+  let commands =
+    List.map(m => formatCommand(readLineFromFile(m)), allMetadataFiles);
+
+  let _ =
+    List.map2(
+      (m, c) => Console.log(m ++ ": " ++ c),
+      relativeMetadataFiles,
+      commands,
+    );
 
   ();
-}
+};
 
 /* I.e. every line up to lines of interest. */
 let logFileHeaderLen = 7;

--- a/library/Logging.re
+++ b/library/Logging.re
@@ -222,10 +222,6 @@ let printPreviousRuns = outputPath => {
       getAllFiles([absPath]),
     );
 
-  /* Get relative paths for pretty printing. */
-  let relativeMetadataFiles =
-    List.map(m => makeRelativePath(absPath, m), allMetadataFiles);
-
   let formatCommand = cmd => stripFirstAndLastFromString(cmd, 3, 1);
   let commands =
     List.map(m => formatCommand(readLineFromFile(m)), allMetadataFiles);
@@ -233,7 +229,7 @@ let printPreviousRuns = outputPath => {
   let _ =
     List.map2(
       (m, c) => Console.log(m ++ ": " ++ c),
-      relativeMetadataFiles,
+      allMetadataFiles,
       commands,
     );
 

--- a/library/Logging.re
+++ b/library/Logging.re
@@ -228,16 +228,26 @@ let printPreviousRuns = outputPath => {
       f => Str.string_match(Str.regexp({|.*meta\.log|}), f, 0),
       getAllFiles([absPath]),
     );
+  /* Get relative paths for pretty printing. */
+  let relativeMetadataFiles =
+    List.map(m => makeRelativePath(absPath, m), allMetadataFiles);
 
   let formatCommand = cmd =>
     stripFirstAndLastFromString(cmd, cmdHeaderLen, codeTagLen);
   let commands =
     List.map(m => formatCommand(readLineFromFile(m)), allMetadataFiles);
 
+  /* Print the location of the configuration first
+   * This lets a consumer either throw away this line
+   * Or use it to go from relative paths to absolute ones.
+   */
+  Console.log(absPath);
+
+  /* Then each of the files with the command in it. */
   let _ =
     List.map2(
       (m, c) => Console.log(m ++ ": " ++ c),
-      allMetadataFiles,
+      relativeMetadataFiles,
       commands,
     );
 

--- a/library/Logging.re
+++ b/library/Logging.re
@@ -10,6 +10,13 @@ open Util;
 open Types.Config;
 open Types.Command;
 
+/* Length of metadata header and code tag. */
+let cmdHeaderLen = 3;
+/* Length of closing header code tag. */
+let codeTagLen = 1;
+/* I.e. every line up to lines of interest. */
+let logFileHeaderLen = 7;
+
 let getLogFilePath = (~time=Unix.gettimeofday(), job, config) => {
   let convertedTime = getLocalDateTime(time);
 
@@ -222,7 +229,8 @@ let printPreviousRuns = outputPath => {
       getAllFiles([absPath]),
     );
 
-  let formatCommand = cmd => stripFirstAndLastFromString(cmd, 3, 1);
+  let formatCommand = cmd =>
+    stripFirstAndLastFromString(cmd, cmdHeaderLen, codeTagLen);
   let commands =
     List.map(m => formatCommand(readLineFromFile(m)), allMetadataFiles);
 
@@ -235,9 +243,6 @@ let printPreviousRuns = outputPath => {
 
   ();
 };
-
-/* I.e. every line up to lines of interest. */
-let logFileHeaderLen = 7;
 
 let getCurrentHeader = (path, config, logMsg) => {
   let currentLogFileLines = open_in(makeAbsolutePath(path));

--- a/library/Logging.re
+++ b/library/Logging.re
@@ -211,6 +211,20 @@ let getLastLogFilePath = (logOutputPath, logMsg) => {
   };
 };
 
+/* Print out every previously ran command, to be grepped over. */
+let printPreviousRuns = (outputPath) => {
+  let absPath = makeAbsolutePath(outputPath);
+  checkFolderExists(absPath);
+
+  let allMetadataFiles = List.filter(
+    f => Str.string_match(Str.regexp({|.*meta\.log|}), f, 0), getAllFiles([absPath])
+  );
+
+  let _ = List.map(f => Console.log(f), allMetadataFiles);
+
+  ();
+}
+
 /* I.e. every line up to lines of interest. */
 let logFileHeaderLen = 7;
 

--- a/library/Logging.rei
+++ b/library/Logging.rei
@@ -9,5 +9,6 @@ let makeLogFile:
   (list(Types.Command.t), Types.Config.t, float, string => unit) => unit;
 let parseCmdOutput: (Types.Config.t, string) => list((int, string));
 let getLastLogFilePath: (string, string => unit) => option(string);
+let printPreviousRuns: (string) => unit;
 let linkOutputToLogFile:
   (string, Types.Config.t, list(string), string => unit) => unit;

--- a/library/Logging.rei
+++ b/library/Logging.rei
@@ -9,6 +9,6 @@ let makeLogFile:
   (list(Types.Command.t), Types.Config.t, float, string => unit) => unit;
 let parseCmdOutput: (Types.Config.t, string) => list((int, string));
 let getLastLogFilePath: (string, string => unit) => option(string);
-let printPreviousRuns: (string) => unit;
+let printPreviousRuns: string => unit;
 let linkOutputToLogFile:
   (string, Types.Config.t, list(string), string => unit) => unit;

--- a/library/PathUtil.re
+++ b/library/PathUtil.re
@@ -109,6 +109,9 @@ let readLineFromFile = path => {
       "";
     };
 
+  /* Close input stream. */
+  close_in(file_input);
+
   line;
 };
 

--- a/library/PathUtil.re
+++ b/library/PathUtil.re
@@ -41,6 +41,14 @@ let makeAbsolutePath = path =>
     path;
   };
 
+let makeRelativePath = (parentPath, path) => {
+  let parentLen = String.length(parentPath);
+  let pathLen = String.length(path);
+
+  /* We want to add one to the start loc to ignore the path seperator. */
+  String.sub(path, parentLen + 1, pathLen - parentLen - 1);
+};
+
 /* Create a folder with some sensible permissions. */
 let makeFolder = path => {
   Unix.mkdir(path, 0o755);
@@ -89,6 +97,19 @@ let writeFile = (path, stringList) => {
       };
 
   writeStringListToFile(fileOut, stringList);
+};
+
+let readLineFromFile = path => {
+  let file_input = open_in(path);
+  let line =
+    try (input_line(file_input)) {
+    | e =>
+      close_in_noerr(file_input);
+      raise(e);
+      "";
+    };
+
+  line;
 };
 
 let getMostRecentFromFolder = (path, shouldBeDirectory) => {

--- a/library/Runner.re
+++ b/library/Runner.re
@@ -113,3 +113,13 @@ let link = (args, logMsg) => {
     Console.error("Could not find a metadata file to link to...");
   };
 };
+
+let printPreviousRuns = (args, logMsg) => {
+  let configPaths = getConfigPaths(args);
+  let config = Config.getConfig(configPaths, logMsg);
+
+  logMsg("Loading all files from " ++ config.outputPath);
+
+  Logging.printPreviousRuns(config.outputPath);
+  ();
+};

--- a/library/Runner.rei
+++ b/library/Runner.rei
@@ -8,3 +8,4 @@ let start:
   (~silent: bool=?, Types.Cli.t, string => unit) =>
   option(Unix.process_status);
 let link: (Types.Cli.t, string => unit) => unit;
+let printPreviousRuns: (Types.Cli.t, string => unit) => unit;

--- a/library/Types.re
+++ b/library/Types.re
@@ -27,7 +27,8 @@ module CommandType = {
     | Run
     | GenerateConfig
     | Link
-    | Search;
+    | Search
+    | ListRuns;
 
   let checkArg = str => {
     switch (str) {
@@ -35,6 +36,7 @@ module CommandType = {
     | "genconfig" => Some(GenerateConfig)
     | "search" => Some(Search)
     | "link" => Some(Link)
+    | "list" => Some(ListRuns)
     | _ => None
     };
   };

--- a/library/Util.re
+++ b/library/Util.re
@@ -96,3 +96,20 @@ let genRandomStr = length => {
   let gen = _ => String.make(1, char_of_int(gen()));
   String.concat("", Array.to_list(Array.init(length, gen)));
 };
+
+let stripFirstNChar = (str, ~n=1) =>
+  if (String.length(str) < n) {
+    str;
+  } else {
+    String.sub(str, n, String.length(str) - n);
+  };
+
+let stripLastNChar = (str, ~n=1) =>
+  if (String.length(str) < n) {
+    str;
+  } else {
+    String.sub(str, 0, String.length(str) - n);
+  };
+
+let stripFirstAndLastFromString = (str, first, last) =>
+  stripFirstNChar(str, ~n=first) |> stripLastNChar(~n=last);


### PR DESCRIPTION
Fixes #34.

Adds a `list` command, that lists the previous runs in the following format:

```
2019-10-01/16:20:39_meta.log: myCommand.sh -i someInput -o someOutput -p ${CWD}
2019-10-01/16:15:21_meta.log: myCommand.sh -i someInput -o someOutput -p ${CWD}
2019-10-01/15:48:23_meta.log: myCommand.sh -i someInput -o someOutput -p ${CWD}
```

The idea being that this can then be piped into FZF to search back over stuff more easily.

Going to leave unmerged, to check what else is missing/will help link up to FZF. I think using the non-relative path might end up being better, else we need a bash script/alias to be work out the config location, which is a pain without using a json parser.